### PR TITLE
minor bug fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ mkdir ~/.config/wallee
 echo "wallee has been installed Restart your i3 to see the changes"
 if [ $shell = "/bin/bash" ]
 then
-`echo "killall wallee" >> $HOME/.bash_logout
+`echo "killall wallee" >> $HOME/.bash_logout`
 elif [ $shell = "/bin/zsh" ]
 then
 `echo "killall wallee" >> $HOME/.zlogout`


### PR DESCRIPTION
missing ` at the end of line 26
fixes the 

> ./install.sh: line 29: unexpected EOF while looking for matching ``'
> ./install.sh: line 44: syntax error: unexpected end of file

issues